### PR TITLE
chore(ci): hardcode database password

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -75,13 +75,13 @@ jobs:
       with:
         mysql database: 'some_test' # Optional, default value is "test". The specified database which will be create
         mysql user: 'developer' # Required if "mysql root password" is empty, default is empty. The superuser for the specified database. Can use secrets, too
-        mysql password: ${{ secrets.DatabasePassword }} # Required if "mysql user" exists. The password for the "mysql user"
+        mysql password: pass # Required if "mysql user" exists. The password for the "mysql user"
 
     - name: Build with Gradle
       uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
       env:
         MYSQL_USER: developer
-        MYSQL_PASSWORD: ${{ secrets.DatabasePassword }}
+        MYSQL_PASSWORD: pass
         MYSQL_DATABASE: some_test
       with:
         arguments: build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,12 +33,12 @@ jobs:
       with:
         mysql database: 'some_test' # Optional, default value is "test". The specified database which will be create
         mysql user: 'developer' # Required if "mysql root password" is empty, default is empty. The superuser for the specified database. Can use secrets, too
-        mysql password: ${{ secrets.DatabasePassword }} # Required if "mysql user" exists. The password for the "mysql user"
+        mysql password: pass # Required if "mysql user" exists. The password for the "mysql user"
     - name: Build with Gradle
       uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
       env:
         MYSQL_USER: developer
-        MYSQL_PASSWORD: ${{ secrets.DatabasePassword }}
+        MYSQL_PASSWORD: pass
         MYSQL_DATABASE: some_test
       with:
         arguments: build


### PR DESCRIPTION
To be able to merge @dependabot PRs we need to hardcode the db password in order to let him run the ci pipeline.